### PR TITLE
Poprawka chatu

### DIFF
--- a/front-end/src/context/ChatContext.js
+++ b/front-end/src/context/ChatContext.js
@@ -1,4 +1,10 @@
-import React, { createContext, useEffect, useState, useContext } from "react";
+import React, {
+  createContext,
+  useEffect,
+  useState,
+  useContext,
+  useCallback,
+} from "react";
 import proxy from "config/api";
 import { UserContext } from "context";
 
@@ -67,11 +73,11 @@ export const ChatProvider = (props) => {
     setChats([...chats, ...res.results]);
   };
 
-  const loadMessages = async () => {
+  const loadMessages = async (token) => {
     setActivePage(1);
     let res;
     try {
-      res = await getChats(user.token, filters);
+      res = await getChats(token, filters);
     } catch (e) {
       setError(true);
       return;

--- a/front-end/src/context/ChatContext.js
+++ b/front-end/src/context/ChatContext.js
@@ -1,10 +1,4 @@
-import React, {
-  createContext,
-  useEffect,
-  useState,
-  useContext,
-  useCallback,
-} from "react";
+import React, { createContext, useEffect, useState, useContext } from "react";
 import proxy from "config/api";
 import { UserContext } from "context";
 

--- a/front-end/src/context/NotificationsContext.js
+++ b/front-end/src/context/NotificationsContext.js
@@ -174,7 +174,7 @@ export const NotificationsProvider = (props) => {
           setCount((prev) => prev + 1);
           setNotifications((prev) => [newNotification, ...prev]);
           if (parsedNotification.app === "chats") {
-            chatC.current.loadMessages();
+            chatC.current.loadMessages(user.token);
           }
         };
         socket.current.onerror = (e) => {


### PR DESCRIPTION
Błąd wywoływało prawdopodobnie zmienienie użytkownika bez odświeżenia strony(funkcja się nie odświeżała i miała w sobie dalej stary token)